### PR TITLE
Conversation Tile Huge Updates

### DIFF
--- a/lib/database/flutterfire.dart
+++ b/lib/database/flutterfire.dart
@@ -90,12 +90,24 @@ Future<String> getName(String userId) async {
   }
 }
 
-Future<bool> deleteConversation(String conversationId) async {
+Future<bool> leaveConversation(String conversationId) async {
   try {
-    await FirebaseFirestore.instance.collection('Conversations').doc(conversationId).delete();
+    // await FirebaseFirestore.instance.collection('Conversations').doc(conversationId).delete();
+    DocumentSnapshot convoSnapshot = await FirebaseFirestore.instance.collection('Conversations').doc(conversationId).get();
+    List<dynamic> people = convoSnapshot.data()['people'];
+
+    if (people.length <= 2) // If only two people are in the convo
+      await FirebaseFirestore.instance.collection('Conversations').doc(conversationId).delete();
+    else {
+      // If Group chat
+      DocumentReference convoRef = FirebaseFirestore.instance.collection('Conversations').doc(conversationId);
+      convoRef.update({
+        'people': FieldValue.arrayRemove([FirebaseAuth.instance.currentUser.uid])
+      });
+    }
     return true;
   } on Exception catch (e) {
-    print("Deletion failed! Error: $e");
+    print("Deletion/Leave failed! Error: $e");
   }
   return false;
 }

--- a/lib/database/flutterfire.dart
+++ b/lib/database/flutterfire.dart
@@ -63,7 +63,11 @@ Future<int> createConversation(List<Account> users, String name) async {
       return -1;
     }
 
-    DocumentReference conRef = await FirebaseFirestore.instance.collection('Conversations').add({'name': name, 'people': userIDs});
+    DocumentReference conRef = await FirebaseFirestore.instance.collection('Conversations').add({
+      'name': name,
+      'people': userIDs,
+      'latestMessageTime': DateTime.now(),
+    });
 
     for (var i = 0; i < userIDs.length; i++) {
       DocumentReference userRef = FirebaseFirestore.instance.collection('Users').doc(userIDs[i]);
@@ -86,7 +90,7 @@ Future<String> getName(String userId) async {
     return name;
   } on Exception catch (e) {
     print(e);
-    return "Error Retrieving Name";
+    return "";
   }
 }
 

--- a/lib/models/Constants.dart
+++ b/lib/models/Constants.dart
@@ -10,20 +10,20 @@ Color secondary = Colors.white;
 
 Message dummyMessage = Message(message: "Hi, this is a dummy message!", timeSent: DateTime.now());
 List<Conversation> dummyConversations = [
-  Conversation(name: "Bible Studies", messages: [Message(message: "Hi", timeSent: DateTime.now())]),
-  Conversation(name: "Holiness is Epic", messages: [Message(message: "Nice", timeSent: DateTime.now().subtract(Duration(days: 1)))]),
-  Conversation(name: "Gimme that 30 bro", messages: [Message(message: "Hah?", timeSent: DateTime.now().subtract(Duration(days: 2)))]),
-  Conversation(name: "Bible is just a history book", messages: [Message(message: "Hatdog", timeSent: DateTime.now().subtract(Duration(days: 3)))]),
-  Conversation(name: "Exam Question Leaks", messages: [Message(message: "GG", timeSent: DateTime.now().subtract(Duration(days: 4)))]),
-  Conversation(name: "Anong Kabostosan Ito?", messages: [Message(message: "Talong", timeSent: DateTime.now().subtract(Duration(days: 5)))]),
-  Conversation(name: "Barkada GC", messages: [Message(message: "Ni", timeSent: DateTime.now().subtract(Duration(days: 6)))]),
+  Conversation(name: "Bible Studies", latestMessage: Message(message: "Hi", timeSent: DateTime.now())),
+  Conversation(name: "Holiness is Epic", latestMessage: Message(message: "Nice", timeSent: DateTime.now().subtract(Duration(days: 1)))),
+  Conversation(name: "Gimme that 30 bro", latestMessage: Message(message: "Hah?", timeSent: DateTime.now().subtract(Duration(days: 2)))),
+  Conversation(name: "Bible is just a history book", latestMessage: Message(message: "Hatdog", timeSent: DateTime.now().subtract(Duration(days: 3)))),
+  Conversation(name: "Exam Question Leaks", latestMessage: Message(message: "GG", timeSent: DateTime.now().subtract(Duration(days: 4)))),
+  Conversation(name: "Anong Kabostosan Ito?", latestMessage: Message(message: "Talong", timeSent: DateTime.now().subtract(Duration(days: 5)))),
+  Conversation(name: "Barkada GC", latestMessage: Message(message: "Ni", timeSent: DateTime.now().subtract(Duration(days: 6)))),
   Conversation(
-      name: "Barkada GC w/out that annoying person", messages: [Message(message: "Joshua", timeSent: DateTime.now().subtract(Duration(days: 7)))]),
-  Conversation(name: "Woke shit", messages: [Message(message: "Andre", timeSent: DateTime.now().subtract(Duration(days: 8)))]),
+      name: "Barkada GC w/out that annoying person", latestMessage: Message(message: "Joshua", timeSent: DateTime.now().subtract(Duration(days: 7)))),
+  Conversation(name: "Woke shit", latestMessage: Message(message: "Andre", timeSent: DateTime.now().subtract(Duration(days: 8)))),
   Conversation(
       name: "Philosophical Debates that amount to nothing",
-      messages: [Message(message: "Nicolai", timeSent: DateTime.now().subtract(Duration(days: 9)))]),
-  Conversation(name: "Conversation Name", messages: [Message(message: "Dotiloss", timeSent: DateTime.now().subtract(Duration(days: 31)))]),
+      latestMessage: Message(message: "Nicolai", timeSent: DateTime.now().subtract(Duration(days: 9)))),
+  Conversation(name: "Conversation Name", latestMessage: Message(message: "Dotiloss", timeSent: DateTime.now().subtract(Duration(days: 31)))),
 ];
 
 ThemeData appTheme = ThemeData(

--- a/lib/models/Conversation.dart
+++ b/lib/models/Conversation.dart
@@ -1,17 +1,18 @@
 import 'package:messaging_app/models/Message.dart';
 
 class Conversation {
-  Conversation({this.name, this.peopleUserId, this.messages});
+  Conversation({this.name = "", this.peopleUserId, this.latestMessage});
 
   String name; // Conversation Name
   List<String> peopleUserId; // List of user ids
-  List<Message>
-      messages; // Should be sorted by timestamp, with latest at the top
+  Message latestMessage;
+  // List<Message>
+  //     messages; // Should be sorted by timestamp, with latest at the top
 
-  Message getLatestMessage() {
-    // To change if ever
-    return this.messages.isEmpty
-        ? Message(senderId: "asd", message: "Empty", timeSent: DateTime.now())
-        : this.messages[0];
-  }
+  // Message getLatestMessage() {
+  //   // To change if ever
+  //   return this.messages.isEmpty
+  //       ? Message(senderId: "asd", message: "Empty", timeSent: DateTime.now())
+  //       : this.messages[0];
+  // }
 }

--- a/lib/screens/conversation_screen.dart
+++ b/lib/screens/conversation_screen.dart
@@ -13,9 +13,7 @@ import 'package:path/path.dart';
 class ConversationScreen extends StatefulWidget {
   final conversationID, name, people;
 
-  const ConversationScreen(
-      {Key key, this.conversationID, this.name, this.people})
-      : super(key: key);
+  const ConversationScreen({Key key, this.conversationID, this.name, this.people}) : super(key: key);
   @override
   _ConversationScreenState createState() => _ConversationScreenState();
 }
@@ -33,10 +31,7 @@ class _ConversationScreenState extends State<ConversationScreen> {
     final _firebaseStorage = firebase_storage.FirebaseStorage.instance;
     if (_image != null) {
       //Upload to Firebase
-      var snapshot = await _firebaseStorage
-          .ref()
-          .child('$userID/$imgName')
-          .putFile(_image);
+      var snapshot = await _firebaseStorage.ref().child('$userID/$imgName').putFile(_image);
       // Get image from firebase
       var downloadUrl = await snapshot.ref.getDownloadURL();
       setState(() {
@@ -49,8 +44,7 @@ class _ConversationScreenState extends State<ConversationScreen> {
   }
 
   Future getImage(String option) async {
-    final pickedFile = await picker.getImage(
-        source: option == "Camera" ? ImageSource.camera : ImageSource.gallery);
+    final pickedFile = await picker.getImage(source: option == "Camera" ? ImageSource.camera : ImageSource.gallery);
 
     setState(() {
       if (pickedFile != null) {
@@ -66,15 +60,15 @@ class _ConversationScreenState extends State<ConversationScreen> {
     void _sendMessage() {
       FocusScope.of(context).unfocus();
 
-      FirebaseFirestore.instance
-          .collection('Conversations')
-          .doc('${widget.conversationID}')
-          .collection('Messages')
-          .add({
+      FirebaseFirestore.instance.collection('Conversations').doc('${widget.conversationID}').collection('Messages').add({
         'senderID': userID,
         'message': _message.text,
         'timeSent': DateTime.now(),
       });
+      FirebaseFirestore.instance.collection('Conversations').doc(widget.conversationID).update({
+        'latestMessageTime': DateTime.now(),
+      });
+
       _message.clear();
     }
 
@@ -85,8 +79,7 @@ class _ConversationScreenState extends State<ConversationScreen> {
           title: Column(
             children: [
               Text(widget.name, style: Theme.of(context).textTheme.headline6),
-              Text("Seen 1 hour ago",
-                  style: Theme.of(context).textTheme.headline6),
+              Text("Seen 1 hour ago", style: Theme.of(context).textTheme.headline6),
             ],
           ),
           actions: [
@@ -109,17 +102,13 @@ class _ConversationScreenState extends State<ConversationScreen> {
                       .orderBy('timeSent', descending: true)
                       .snapshots(),
                   builder: (_, chatSnapshot) {
-                    if (chatSnapshot.connectionState !=
-                        ConnectionState.waiting) {
+                    if (chatSnapshot.connectionState != ConnectionState.waiting) {
                       _messages = [];
                       // Snapshot to List
-                      chatSnapshot.data.docs
-                          .map((QueryDocumentSnapshot document) {
+                      chatSnapshot.data.docs.map((QueryDocumentSnapshot document) {
                         print("GG");
-                        return _messages.add(Message(
-                            senderId: document['senderID'],
-                            timeSent: document['timeSent'].toDate(),
-                            message: document['message']));
+                        return _messages
+                            .add(Message(senderId: document['senderID'], timeSent: document['timeSent'].toDate(), message: document['message']));
                       }).toList();
                       _messages.reversed.toList();
                       return ListView.builder(
@@ -127,26 +116,13 @@ class _ConversationScreenState extends State<ConversationScreen> {
                           itemCount: chatSnapshot.data.size,
                           itemBuilder: (_, index) {
                             return Row(
-                              mainAxisAlignment:
-                                  _messages[index].senderId == userID
-                                      ? MainAxisAlignment.end
-                                      : MainAxisAlignment.start,
+                              mainAxisAlignment: _messages[index].senderId == userID ? MainAxisAlignment.end : MainAxisAlignment.start,
                               children: [
-                                if (_messages[index].senderId != userID)
-                                  Image(
-                                      width: 35,
-                                      height: 35,
-                                      image:
-                                          NetworkImage(kDefaultProfilePicture)),
+                                if (_messages[index].senderId != userID) Image(width: 35, height: 35, image: NetworkImage(kDefaultProfilePicture)),
                                 Padding(
-                                  padding: const EdgeInsets.only(
-                                      left: 10.0, bottom: 5.0),
+                                  padding: const EdgeInsets.only(left: 10.0, bottom: 5.0),
                                   child: ChatBubble(
-                                      messages: _messages,
-                                      index: index,
-                                      color: _messages[index].senderId != userID
-                                          ? Colors.white
-                                          : Colors.black),
+                                      messages: _messages, index: index, color: _messages[index].senderId != userID ? Colors.white : Colors.black),
                                 ),
                               ],
                             );
@@ -172,8 +148,7 @@ class _ConversationScreenState extends State<ConversationScreen> {
                     child: Container(
                       margin: EdgeInsets.all(5.0),
                       decoration: BoxDecoration(
-                        border: Border.all(
-                            color: Theme.of(context).primaryColorLight),
+                        border: Border.all(color: Theme.of(context).primaryColorLight),
                         borderRadius: BorderRadius.all(Radius.circular(50.0)),
                       ),
                       child: TextFormField(
@@ -184,15 +159,11 @@ class _ConversationScreenState extends State<ConversationScreen> {
                             contentPadding: EdgeInsets.all(13.0),
                             border: InputBorder.none,
                             hintText: "Enter your message...",
-                            hintStyle: TextStyle(
-                                color: Theme.of(context).primaryColorLight)),
+                            hintStyle: TextStyle(color: Theme.of(context).primaryColorLight)),
                       ),
                     ),
                   ),
-                  IconButton(
-                      color: Theme.of(context).primaryColorLight,
-                      icon: Icon(Icons.send),
-                      onPressed: _sendMessage),
+                  IconButton(color: Theme.of(context).primaryColorLight, icon: Icon(Icons.send), onPressed: _sendMessage),
                 ],
               ),
             ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -31,12 +31,10 @@ class _HomeScreenState extends State<HomeScreen> {
           alignment: Alignment.center,
           // color: Colors.yellow, // To see boundaries
           child: IconButton(
-            icon:
-                Icon(Icons.person, color: Theme.of(context).primaryColorLight),
+            icon: Icon(Icons.person, color: Theme.of(context).primaryColorLight),
             onPressed: () {
               signOut();
-              Navigator.pushReplacement(context,
-                  MaterialPageRoute(builder: (context) => LandingScreen()));
+              Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) => LandingScreen()));
             },
           ),
         ),
@@ -45,10 +43,7 @@ class _HomeScreenState extends State<HomeScreen> {
             icon: Icon(Icons.edit, color: Theme.of(context).primaryColorLight),
             onPressed: () {
               // Create New Conversation
-              Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                      builder: (context) => NewConversationScreen()));
+              Navigator.push(context, MaterialPageRoute(builder: (context) => NewConversationScreen()));
             },
           ),
         ],
@@ -57,14 +52,9 @@ class _HomeScreenState extends State<HomeScreen> {
           children: [
             Text(
               "sent",
-              style: TextStyle(
-                  fontFamily: "Barlow",
-                  color: Theme.of(context).primaryColorLight),
+              style: TextStyle(fontFamily: "Barlow", color: Theme.of(context).primaryColorLight),
             ),
-            Text("ence",
-                style: TextStyle(
-                    fontFamily: "Barlow",
-                    color: Theme.of(context).primaryColorDark)),
+            Text("ence", style: TextStyle(fontFamily: "Barlow", color: Theme.of(context).primaryColorDark)),
           ],
         ),
       ),
@@ -74,9 +64,7 @@ class _HomeScreenState extends State<HomeScreen> {
           Container(
             height: 50.0,
             margin: EdgeInsets.symmetric(vertical: 4.0),
-            padding: EdgeInsets.symmetric(
-                vertical: 2.0,
-                horizontal: MediaQuery.of(context).size.width * 0.08),
+            padding: EdgeInsets.symmetric(vertical: 2.0, horizontal: MediaQuery.of(context).size.width * 0.08),
             alignment: Alignment.center,
             child: Container(
               decoration: BoxDecoration(
@@ -97,10 +85,8 @@ class _HomeScreenState extends State<HomeScreen> {
                 decoration: InputDecoration(
                   border: InputBorder.none,
                   hintText: "Search Conversation",
-                  hintStyle:
-                      TextStyle(color: Theme.of(context).primaryColorLight),
-                  prefixIcon: Icon(Icons.search,
-                      color: Theme.of(context).primaryColorLight),
+                  hintStyle: TextStyle(color: Theme.of(context).primaryColorLight),
+                  prefixIcon: Icon(Icons.search, color: Theme.of(context).primaryColorLight),
                   // icon: Icon(Icons.search, color: Theme.of(context).primaryColorLight),
                 ),
               ),
@@ -111,22 +97,17 @@ class _HomeScreenState extends State<HomeScreen> {
             child: StreamBuilder(
               stream: FirebaseFirestore.instance
                   .collection("Conversations")
-                  .where("people",
-                      arrayContains: FirebaseAuth.instance.currentUser.uid)
+                  .where("people", arrayContains: FirebaseAuth.instance.currentUser.uid)
+                  // .orderBy("latestMessageTime")
                   .snapshots(),
-              builder: (BuildContext context,
-                  AsyncSnapshot<QuerySnapshot> snapshot) {
+              builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
                 print(FirebaseAuth.instance.currentUser.uid);
-                if (!snapshot.hasData)
-                  return Center(child: CircularProgressIndicator());
+                if (!snapshot.hasData) return Center(child: CircularProgressIndicator());
                 return ListView(
-                  children:
-                      snapshot.data.docs.map((QueryDocumentSnapshot document) {
-                    return document['name']
-                            .toLowerCase()
-                            .contains(_searchConvo.value.text.toLowerCase())
-                        ? ConversationTile(document.id, document['name'],
-                            document['people'], dummyMessage)
+                  children: snapshot.data.docs.map((QueryDocumentSnapshot document) {
+                    print("${document.data()['name']}");
+                    return document['name'].toLowerCase().contains(_searchConvo.value.text.toLowerCase())
+                        ? ConversationTile(document.id, document.data()['name'], document.data()['people'])
                         : SizedBox(width: 0, height: 0);
                   }).toList(),
                 );
@@ -143,8 +124,7 @@ class _HomeScreenState extends State<HomeScreen> {
         currentIndex: bottomNavIndex,
         onTap: (value) => setState(() => bottomNavIndex = value),
         items: [
-          BottomNavigationBarItem(
-              label: "Conversations", icon: Icon(Icons.chat_bubble)),
+          BottomNavigationBarItem(label: "Conversations", icon: Icon(Icons.chat_bubble)),
           BottomNavigationBarItem(label: "Friends", icon: Icon(Icons.group)),
         ],
       ),

--- a/lib/widgets/conversation_tile.dart
+++ b/lib/widgets/conversation_tile.dart
@@ -11,10 +11,7 @@ import 'package:messaging_app/database/flutterfire.dart';
 import 'dart:math'; // for RNG, 2 remove later
 
 class ConversationTile extends StatefulWidget {
-  const ConversationTile(
-      this.conversationId, this.name, this.people, this.message,
-      {Key key})
-      : super(key: key);
+  const ConversationTile(this.conversationId, this.name, this.people, this.message, {Key key}) : super(key: key);
   final people;
   final String name, conversationId;
   final Message message;
@@ -39,21 +36,14 @@ class _ConversationTileState extends State<ConversationTile> {
   Widget build(BuildContext context) {
     String sender = ""; // To get name of userId
     String time = "Time"; // Just in case of error
-    DateTime messageDay = widget.message.timeSent,
-        today = DateTime.now(),
-        lastWeek = DateTime.now().subtract(Duration(days: 7));
+    DateTime messageDay = widget.message.timeSent, today = DateTime.now(), lastWeek = DateTime.now().subtract(Duration(days: 7));
 
-    if (today.day == messageDay.day &&
-        today.month == messageDay.month &&
-        today.year == messageDay.year)
-      time = DateFormat.jm()
-          .format(widget.message.timeSent); // Same day, just time
+    if (today.day == messageDay.day && today.month == messageDay.month && today.year == messageDay.year)
+      time = DateFormat.jm().format(widget.message.timeSent); // Same day, just time
     else if (messageDay.compareTo(lastWeek) >= 0)
-      time = DateFormat.E()
-          .format(widget.message.timeSent); // WeekdayAbbr e.g. Fri
+      time = DateFormat.E().format(widget.message.timeSent); // WeekdayAbbr e.g. Fri
     else
-      time = DateFormat.MMMd()
-          .format(widget.message.timeSent); // MonthAbbr Date e.g. Mar 1
+      time = DateFormat.MMMd().format(widget.message.timeSent); // MonthAbbr Date e.g. Mar 1
 
     // to remove later
     var rng = Random();
@@ -68,14 +58,12 @@ class _ConversationTileState extends State<ConversationTile> {
           background: Container(
             alignment: Alignment.centerLeft,
             margin: EdgeInsets.only(left: 20.0),
-            child: Icon(Icons.more,
-                color: Theme.of(context).primaryColorLight, size: 30),
+            child: Icon(Icons.more, color: Theme.of(context).primaryColorLight, size: 30),
           ),
           secondaryBackground: Container(
             alignment: Alignment.centerRight,
             margin: EdgeInsets.only(right: 20.0),
-            child: Icon(Icons.delete,
-                color: Theme.of(context).primaryColorLight, size: 30),
+            child: Icon(Icons.delete, color: Theme.of(context).primaryColorLight, size: 30),
           ),
           confirmDismiss: (direction) async {
             bool dismiss = false;
@@ -83,13 +71,11 @@ class _ConversationTileState extends State<ConversationTile> {
               // Delete
               dismiss = await showDialog<bool>(
                 context: context,
-                builder: (BuildContext context) =>
-                    DeleteConversationAlertDialog(),
+                builder: (BuildContext context) => DeleteConversationAlertDialog(),
               );
               bool delSuccess = false;
-              if (dismiss) delSuccess = await deleteConversation(widget.conversationId);
-              if (delSuccess) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Conversation deleted.')));
-              this.dispose();
+              if (dismiss) delSuccess = await leaveConversation(widget.conversationId);
+              if (delSuccess) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Left conversation.')));
             } else {
               // More
               print("More");
@@ -100,10 +86,7 @@ class _ConversationTileState extends State<ConversationTile> {
             onTap: () => Navigator.push(
                 context,
                 MaterialPageRoute(
-                    builder: (context) => ConversationScreen(
-                        conversationID: widget.conversationId,
-                        name: snapshot.data,
-                        people: widget.people))),
+                    builder: (context) => ConversationScreen(conversationID: widget.conversationId, name: snapshot.data, people: widget.people))),
             child: Container(
               height: 75.0,
               width: MediaQuery.of(context).size.width,
@@ -131,10 +114,7 @@ class _ConversationTileState extends State<ConversationTile> {
                       children: [
                         Text(
                           "${snapshot.data}",
-                          style: TextStyle(
-                              color: Colors.black,
-                              fontWeight: FontWeight.w700,
-                              fontSize: 16.0),
+                          style: TextStyle(color: Colors.black, fontWeight: FontWeight.w700, fontSize: 16.0),
                         ),
                         Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -146,8 +126,7 @@ class _ConversationTileState extends State<ConversationTile> {
                                 style: TextStyle(color: Colors.grey),
                               ),
                             ),
-                            Text("$time",
-                                style: TextStyle(color: Colors.black)),
+                            Text("$time", style: TextStyle(color: Colors.black)),
                           ],
                         ),
                       ],
@@ -171,8 +150,7 @@ class DeleteConversationAlertDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog(
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15)),
-      title: Text("Delete Conversation?",
-          style: Theme.of(context).textTheme.bodyText1),
+      title: Text("Leave Conversation?", style: Theme.of(context).textTheme.bodyText1),
       actions: <Widget>[
         TextButton(
           child: Text("No", style: TextStyle(color: Colors.grey)),
@@ -180,9 +158,7 @@ class DeleteConversationAlertDialog extends StatelessWidget {
         ),
         Container(
           padding: EdgeInsets.symmetric(horizontal: 10),
-          decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(5),
-              color: Theme.of(context).primaryColorLight),
+          decoration: BoxDecoration(borderRadius: BorderRadius.circular(5), color: Theme.of(context).primaryColorLight),
           child: TextButton(
             style: TextButton.styleFrom(backgroundColor: primaryLight),
             child: Text("Yes", style: TextStyle(color: Colors.white)),


### PR DESCRIPTION
-modified flutterfire.dart's createConversation() and conversation_screen.dart's _sendMessage() to include new Conversation field called 'latestMessageTime'
-conversation tile now sorted according to latest message, and shows the latest message, its sender, and time sent.
-conversation tile now dismisses properly when dismissed by swiping to the left: in DMs the conversation is deleted; but in GCs the user just leaves the conversation, leaving the rest in the group